### PR TITLE
Fix issue of principal_point_y setting in render_intrinsics

### DIFF
--- a/external/mesh-fusion/2_fusion.py
+++ b/external/mesh-fusion/2_fusion.py
@@ -38,7 +38,7 @@ class Fusion:
             self.options.focal_length_x,
             self.options.focal_length_y,
             self.options.principal_point_x,
-            self.options.principal_point_x
+            self.options.principal_point_y,
         ], dtype=float)
         # Essentially the same as above, just a slightly different format.
         self.fusion_intrisics = np.array([


### PR DESCRIPTION
It won't affect the current default setting where cx and cy share the same value. However, it will cause the wrong render_intrinsics to be used if the user chooses a different intrinsic parameter