### PR TITLE
Add missing include_dirs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ pykdtree = Extension(
     language='c',
     extra_compile_args=['-std=c99', '-O3', '-fopenmp'],
     extra_link_args=['-lgomp'],
+    include_dirs=[numpy_include_dir]
 )
 
 # mcubes (marching cubes algorithm)


### PR DESCRIPTION
Hi,
In the setup.py file, the Extension of pykdtree should also have the argument include_dirs=[numpy.get_include()]. Otherwise it returns error "[Cython: "fatal error: numpy/arrayobject.h: No such file or directory"]" when I run python setup.py build_ext --inplace
(As a person who doesn't know cpython at the beginning the error makes us unable to rebuild the project and likely to give up)
Best regard